### PR TITLE
Fix naming for controllers/models for certain endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 #Ignore these files
+tests/
 .pypirc
 build/
 .idea/

--- a/cohesity_management_sdk/controllers/active_directory.py
+++ b/cohesity_management_sdk/controllers/active_directory.py
@@ -9,7 +9,7 @@ from cohesity_management_sdk.http.auth.auth_manager import AuthManager
 from cohesity_management_sdk.models.domain_controllers import DomainControllers
 from cohesity_management_sdk.models.non_local_group_or_user import NonLOCALGroupOrUser
 from cohesity_management_sdk.models.active_directory_principal import ActiveDirectoryPrincipal
-from cohesity_management_sdk.models.active_directory import ActiveDirectory
+from cohesity_management_sdk.models.active_directory import ActiveDirectory1
 from cohesity_management_sdk.models.list_centrify_zone import ListCentrifyZone
 from cohesity_management_sdk.exceptions.error_error_exception import ErrorErrorException
 
@@ -310,7 +310,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -376,7 +376,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -442,7 +442,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -508,7 +508,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -575,7 +575,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -641,7 +641,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -825,7 +825,7 @@ class ActiveDirectory(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, ActiveDirectory1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)

--- a/cohesity_management_sdk/controllers/interface_group.py
+++ b/cohesity_management_sdk/controllers/interface_group.py
@@ -6,7 +6,7 @@ from cohesity_management_sdk.api_helper import APIHelper
 from cohesity_management_sdk.configuration import Configuration
 from cohesity_management_sdk.controllers.base_controller import BaseController
 from cohesity_management_sdk.http.auth.auth_manager import AuthManager
-from cohesity_management_sdk.models.interface_group import InterfaceGroup
+from cohesity_management_sdk.models.interface_group import InterfaceGroup1
 from cohesity_management_sdk.exceptions.error_error_exception import ErrorErrorException
 
 class InterfaceGroup(BaseController):
@@ -61,7 +61,7 @@ class InterfaceGroup(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -169,7 +169,7 @@ class InterfaceGroup(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -225,7 +225,7 @@ class InterfaceGroup(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, InterfaceGroup1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)

--- a/cohesity_management_sdk/controllers/remote_cluster.py
+++ b/cohesity_management_sdk/controllers/remote_cluster.py
@@ -7,7 +7,7 @@ from cohesity_management_sdk.configuration import Configuration
 from cohesity_management_sdk.controllers.base_controller import BaseController
 from cohesity_management_sdk.http.auth.auth_manager import AuthManager
 from cohesity_management_sdk.models.replication_encryption_key import ReplicationEncryptionKey
-from cohesity_management_sdk.models.remote_cluster import RemoteCluster
+from cohesity_management_sdk.models.remote_cluster import RemoteCluster1
 from cohesity_management_sdk.exceptions.error_error_exception import ErrorErrorException
 
 class RemoteCluster(BaseController):
@@ -193,7 +193,7 @@ class RemoteCluster(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -256,7 +256,7 @@ class RemoteCluster(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -323,7 +323,7 @@ class RemoteCluster(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)
@@ -387,7 +387,7 @@ class RemoteCluster(BaseController):
             self.validate_response(_context)
 
             # Return appropriate type
-            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster.from_dictionary)
+            return APIHelper.json_deserialize(_context.response.raw_body, RemoteCluster1.from_dictionary)
 
         except Exception as e:
             self.logger.error(e, exc_info = True)

--- a/cohesity_management_sdk/models/active_directory.py
+++ b/cohesity_management_sdk/models/active_directory.py
@@ -4,7 +4,7 @@
 import cohesity_management_sdk.models.user_id_mapping
 import cohesity_management_sdk.models.update_preferred_domain_controller_request
 
-class ActiveDirectory(object):
+class ActiveDirectory1(object):
 
     """Implementation of the 'Active Directory.' model.
 

--- a/cohesity_management_sdk/models/interface_group.py
+++ b/cohesity_management_sdk/models/interface_group.py
@@ -3,7 +3,7 @@
 
 import cohesity_management_sdk.models.product_model_and_interface_tuple
 
-class InterfaceGroup(object):
+class InterfaceGroup1(object):
 
     """Implementation of the 'InterfaceGroup.' model.
 

--- a/cohesity_management_sdk/models/remote_cluster.py
+++ b/cohesity_management_sdk/models/remote_cluster.py
@@ -5,7 +5,7 @@ import cohesity_management_sdk.models.bandwidth_limit
 import cohesity_management_sdk.models.create_access_token_credential_request
 import cohesity_management_sdk.models.storage_domain_view_box_pairing
 
-class RemoteCluster(object):
+class RemoteCluster1(object):
 
     """Implementation of the 'Remote Cluster.' model.
 


### PR DESCRIPTION
The following endpoints needed these fixes since the ModelName and ControllerNames were similar.
1. ActiveDirectory
2. RemoteCluster
3. InterfaceGroup