### PR TITLE
added sample for listing protection runs status

### DIFF
--- a/cohesity_management_sdk/samples/protection_runs_status/README.md
+++ b/cohesity_management_sdk/samples/protection_runs_status/README.md
@@ -1,20 +1,34 @@
-Samples for Cohesity Management SDK 
-========================
-This repository contains reference samples for Cohesity Management SDK.
- 
-### Get Protection Run Status
+## Usage 
+```
+python protection_runs_status.py
+```
+Output is formatteed as
 
-[README](protection_run_status/README.md)
+```
+date time job_name job_run_id status
+```
 
-### Handling Errors.
-[README](handling_errors/README.md)
+## Connect to the Cohesity Cluster
+First make sure that you are connected to a Cohesity Cluster.
+```
+cohesity_client = CohesityClient(cluster_vip=CLUSTER_VIP,
+                                 username=CLUSTER_USERNAME, 
+                                 password=CLUSTER_PASSWORD,
+                                 domain=DOMAIN)
+```
+Note: Alternatively, you can set the above parameters in cohesity_management_sdk/configuration.py
 
-### List Protection Jobs.
-[README](list_protection_jobs/README.md)
+## Example
+``` 
+protection_runs = cohesity_client.protection_runs
+run_list = protection_runs.get_protection_runs()
 
-### List Unresolved Alerts.
-[README](list_unresolved_alerts/README.md)
-
-### Running a Protection Job on demand.
-[README](on_demand_job_run/README.md)
+```
+## Example Output
+```
+10-21-2019 11:44:45 SQL_File_CBT 166561 kSuccess
+10-21-2019 22:09:00 MSMITH-Demo 167096 kSuccess
+10-21-2019 17:27:01 Protect_Delete_me_andy 166885 kSuccess
+10-22-2019 08:43:05 Replica 167605 kSuccess
+```
 

--- a/cohesity_management_sdk/samples/protection_runs_status/README.md
+++ b/cohesity_management_sdk/samples/protection_runs_status/README.md
@@ -1,0 +1,20 @@
+Samples for Cohesity Management SDK 
+========================
+This repository contains reference samples for Cohesity Management SDK.
+ 
+### Get Protection Run Status
+
+[README](protection_run_status/README.md)
+
+### Handling Errors.
+[README](handling_errors/README.md)
+
+### List Protection Jobs.
+[README](list_protection_jobs/README.md)
+
+### List Unresolved Alerts.
+[README](list_unresolved_alerts/README.md)
+
+### Running a Protection Job on demand.
+[README](on_demand_job_run/README.md)
+

--- a/cohesity_management_sdk/samples/protection_runs_status/protection_run_status.py
+++ b/cohesity_management_sdk/samples/protection_runs_status/protection_run_status.py
@@ -8,12 +8,10 @@ import datetime
 
 from cohesity_management_sdk.cohesity_client import CohesityClient
 
-CLUSTER_USERNAME = 'USERNAME'
-CLUSTER_PASSWORD = 'PASSWORD'
-CLUSTER_VIP = 'VIP_OR_FQDN'
-DOMAIN = 'LOCAL'
-
-#job_id = 
+CLUSTER_VIP = 'CLUSTER_VIP'
+CLUSTER_USERNAME = 'CLUSTER_USERNAME'
+CLUSTER_PASSWORD = 'CLUSTER_PASSWORD'
+DOMAIN = 'DOMAIN'
 
 class ProtectionRunsList(object):
 
@@ -24,10 +22,9 @@ class ProtectionRunsList(object):
         :return:
         """
         protection_runs = cohesity_client.protection_runs
-        # run_list = protection_runs.get_protection_runs(job_id)
         run_list = protection_runs.get_protection_runs()
         for run in run_list:
-            print(self.epoch_to_date(run.backup_run.stats.start_time_usecs), run.backup_run.job_run_id, run.backup_run.status)
+            print(self.epoch_to_date(run.backup_run.stats.start_time_usecs), run.job_name, run.backup_run.job_run_id, run.backup_run.status)
 
     @staticmethod
     def epoch_to_date(epoch):

--- a/cohesity_management_sdk/samples/protection_runs_status/protection_run_status.py
+++ b/cohesity_management_sdk/samples/protection_runs_status/protection_run_status.py
@@ -1,0 +1,53 @@
+# Copyright 2019 Cohesity Inc.
+#
+# Python example to get a status of a protection run
+#
+# Usage: python protection_run_status.py
+
+import datetime
+
+from cohesity_management_sdk.cohesity_client import CohesityClient
+
+CLUSTER_USERNAME = 'USERNAME'
+CLUSTER_PASSWORD = 'PASSWORD'
+CLUSTER_VIP = 'VIP_OR_FQDN'
+DOMAIN = 'LOCAL'
+
+#job_id = 
+
+class ProtectionRunsList(object):
+
+    def display_protection_runs(self, cohesity_client):
+        """
+        Method to display the list of protection runs
+        :param cohesity_client(object): Cohesity client object.
+        :return:
+        """
+        protection_runs = cohesity_client.protection_runs
+        # run_list = protection_runs.get_protection_runs(job_id)
+        run_list = protection_runs.get_protection_runs()
+        for run in run_list:
+            print(self.epoch_to_date(run.backup_run.stats.start_time_usecs), run.backup_run.job_run_id, run.backup_run.status)
+
+    @staticmethod
+    def epoch_to_date(epoch):
+        """
+        Method to convert epoch time in usec to date format
+        :param epoch(int): Epoch time of the job run.
+        :return: date(str): Date format of the job runj.
+        """
+        date = datetime.datetime.fromtimestamp(epoch/10**6).\
+            strftime('%m-%d-%Y %H:%M:%S')
+        return date
+
+def main():
+
+    cohesity_client = CohesityClient(cluster_vip=CLUSTER_VIP,
+                                     username=CLUSTER_USERNAME,
+                                     password=CLUSTER_PASSWORD,
+				                     domain=DOMAIN)
+    protection_runs = ProtectionRunsList()
+    protection_runs.display_protection_runs(cohesity_client)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
added a sample script for checking the status on protection runs. Currently only prints a formatted start_time_usecs, job_run_id, and status.