### PR TITLE
Mssql Fix: Protect few instances of a Source

### DIFF
--- a/samples/project-anfield/export_cluster_config.py
+++ b/samples/project-anfield/export_cluster_config.py
@@ -63,7 +63,9 @@ cluster_dict = {
     "protection_sources": library.get_protection_sources(cohesity_client),
     "external_targets": library.get_external_targets(cohesity_client),
     "sources": library.get_protection_sources(cohesity_client),
-    "remote_clusters": library.get_remote_clusters(cohesity_client)
+    "remote_clusters": library.get_remote_clusters(cohesity_client),
+    "sql_entity_mapping": library.get_sql_entity_mapping(cohesity_client,
+                                                         env_enum.KSQL)
 }
 
 exported_res = library.debug()

--- a/samples/project-anfield/library.py
+++ b/samples/project-anfield/library.py
@@ -92,9 +92,33 @@ def get_external_targets(cohesity_client):
     return external_target_list
 
 
-def get_remote_clusters(coheity_client):
-    remote_cluster_list = coheity_client.remote_cluster.get_remote_clusters()
+def get_remote_clusters(cohesity_client):
+    remote_cluster_list = cohesity_client.remote_cluster.get_remote_clusters()
     return remote_cluster_list
+
+
+def get_sql_entity_mapping(cohesity_client, env):
+    """
+    Function to fetch SQL sources available in the cluster along with instance
+    name and ids.
+    """
+    sql_mapping = {}
+    sources = cohesity_client.protection_sources.list_protection_sources(
+        environment=env)
+    if not sources:
+        return sql_mapping
+    # Iterate each node(sql server) and fetch database available in the
+    # server.
+    for source in sources[0].nodes:
+        _id = source["protectionSource"]["id"]
+        sql_mapping[_id] = {}
+        if source.get("applicationNodes"):
+            nodes = source["applicationNodes"]
+            for sql_node in nodes:
+                for node in sql_node["nodes"]:
+                    sql_mapping[_id][node["protectionSource"]["id"]] = node[
+                    "protectionSource"]["name"]
+    return sql_mapping
 
 
 def debug():


### PR DESCRIPTION
Issue:
 If a Job(sql source) is imported, error araised while
assigning few instances of a server to job.

Fix:
 While exporting, sql server databases and ids are fetched
while can be used while importing sql jobs.