### PR TITLE
Anfield Enhancements: Specific Import & Storage domain Import Fix

### DIFF
--- a/samples/project-anfield/config.ini
+++ b/samples/project-anfield/config.ini
@@ -21,6 +21,8 @@ gflag=False
 # prefix and suffix added to Jobname. By default no prefix/suffix is added.
 job_prefix=
 job_suffix=
+# List of jobs to be imported. Accepts list of comma separated strings.
+selected_jobs=job1,job2,job3
 
 [Remote Cluster Name] # Remote Cluster 1
 password=<password>

--- a/samples/project-anfield/config.ini
+++ b/samples/project-anfield/config.ini
@@ -19,8 +19,8 @@ override=True
 # gflag parameter is for to decide whether to import gflags.
 gflag=False
 # prefix and suffix added to Jobname. By default no prefix/suffix is added.
-job_prefix=
-job_suffix=
+imported_job_prefix=
+imported_job_suffix=
 # List of jobs to be imported. Accepts list of comma separated strings.
 selected_jobs=job1,job2,job3
 

--- a/samples/project-anfield/config.ini
+++ b/samples/project-anfield/config.ini
@@ -18,6 +18,9 @@ pause_jobs=True
 override=True
 # gflag parameter is for to decide whether to import gflags.
 gflag=False
+# prefix and suffix added to Jobname. By default no prefix/suffix is added.
+job_prefix=
+job_suffix=
 
 [Remote Cluster Name] # Remote Cluster 1
 password=<password>

--- a/samples/project-anfield/export_cluster_config.py
+++ b/samples/project-anfield/export_cluster_config.py
@@ -143,7 +143,7 @@ elif file_name:
 # Fetch all the resources and store the data in file.
 pickle.dump(cluster_dict, open(exported_config_file, "wb"))
 
-logger.info("Please find the imported resources summary.\n")
+logger.info("Please find the exported resources summary.\n")
 for key, val in exported_res.items():
     logger.info("Successfully exported the following %s:\n%s\n" %
                 (key, ", ".join(val)))

--- a/samples/project-anfield/import_cluster_config.py
+++ b/samples/project-anfield/import_cluster_config.py
@@ -660,8 +660,8 @@ def create_protection_jobs():
     sql_parent_source = None
     existing_job_list = {}
     active_protection_jobs = []
-    job_prefix = configparser.get("import_cluster_config", "job_prefix")
-    job_suffix = configparser.get("import_cluster_config", "job_suffix")
+    imported_job_prefix = configparser.get("import_cluster_config", "imported_job_prefix")
+    imported_job_suffix = configparser.get("import_cluster_config", "imported_job_suffix")
     active_protection_jobs = cluster_dict.get("protection_jobs", [])
 
     # Fetch Sql parent source id.
@@ -690,8 +690,8 @@ def create_protection_jobs():
                 # the jobs are protected, or else only selected jobs are
                 # protected.
                 continue
-            if job_prefix or job_suffix:
-                job_name = job_prefix + job_name + job_suffix
+            if imported_job_prefix or imported_job_suffix:
+                job_name = imported_job_prefix + job_name + imported_job_suffix
                 protection_job.name = job_name
             environment = protection_job.environment
             parent_id = protection_job.parent_source_id

--- a/samples/project-anfield/import_cluster_config.py
+++ b/samples/project-anfield/import_cluster_config.py
@@ -100,8 +100,6 @@ else:
         print("Import file does not exist")
         sys.exit(1)
 
-with open("resources.json") as file_obj:
-    resources_to_import = json.load(file_obj)
 
 # Variables to store resources and corresponding ids.
 
@@ -133,18 +131,12 @@ def import_cluster_config():
 def create_vaults():
     available_vaults_dict = {}
     vaults = cluster_dict.get("external_targets")
-    targets_to_import = resources_to_import.get("external_targets", [])
     available_vaults = library.get_external_targets(cohesity_client)
 
     for vault in available_vaults:
         available_vaults_dict[vault.name] = vault.id
 
     for vault in vaults:
-        if targets_to_import and vault.name not in targets_to_import:
-            # If target is not listed under required target list, target is
-            # not imported, if list is empty all the external targets are
-            # imported.
-            continue
         if vault.name in available_vaults_dict.keys():
             imported_res_dict["External Targets"].append(vault.name)
             continue
@@ -432,7 +424,6 @@ def create_storage_domains():
     """
     existing_storage_domain_list = {}
     try:
-        viewboxes_to_import = resources_to_import.get("viewboxes", [])
         existing_storage_domains = library.get_storage_domains(cohesity_client)
 
         for storage_domain in existing_storage_domains:
@@ -440,10 +431,6 @@ def create_storage_domains():
         storage_domain_list = cluster_dict.get("storage_domains", [])
 
         for storage_domain in storage_domain_list:
-            if viewboxes_to_import and storage_domain.name not in viewboxes_to_import:
-                # If viewbox is not listed under required viewboxes list, viewbox is
-                # not imported, if list is empty all the viewboxes are imported.
-                continue
             if storage_domain.name in existing_storage_domain_list.keys():
                 new_storage_domain_id = existing_storage_domain_list[storage_domain.name]
                 storage_domain_mapping[storage_domain.id] = new_storage_domain_id
@@ -483,7 +470,6 @@ def create_protection_sources():
         "name"] for source in sql_sources[0].nodes]
 
     try:
-        sources_to_import = resources_to_import.get("sources", [])
         existing_sources = library.get_protection_sources(cohesity_client)
         for source in existing_sources:
             env = (source.protection_source.environment)
@@ -507,10 +493,6 @@ def create_protection_sources():
             if environment not in env_list:
                 continue
             source_name = source.protection_source.name
-            if sources_to_import and source_name not in sources_to_import:
-                # If source is not listed under required sources list, source is
-                # not imported, if list is empty all the sources are imported.
-                continue
             id = source.protection_source.id
 
             if environment == env_enum.KVIEW:
@@ -560,16 +542,11 @@ def create_views():
     view is not available in exported list.
     """
     existing_view_dict = {}
-    views_to_import = resources_to_import.get("views", [])
     view_list = cluster_dict.get("views", [])
     existing_views = library.get_views(cohesity_client)
     for view in existing_views:
         existing_view_dict[view.name] = view.view_id
     for view in view_list:
-        if views_to_import and view.name not in views_to_import:
-            # If view is not listed under required views list, view is
-            # not imported, if list is empty all the views are imported.
-            continue
         try:
             if view.name in existing_view_dict.keys():
                 imported_res_dict["Protection Views"].append(view.name)
@@ -607,7 +584,6 @@ def create_protection_policies():
     """
     existing_policy_list = {}
     protection_policy_list = cluster_dict.get("policies", [])
-    policies_to_import = resources_to_import.get("policies", [])
     existing_policies = library.get_protection_policies(cohesity_client)
     for policy in existing_policies:
         existing_policy_list[policy.name] = policy.id
@@ -615,10 +591,6 @@ def create_protection_policies():
     for policy in protection_policy_list:
         is_policy_available = False
         try:
-            if policies_to_import and policy.name not in policies_to_import:
-                # If policy is not listed under required policy list, view is
-                # not imported, if list is empty all the policies are imported.
-                continue
             # If policy with same name is already available.
             if policy.name in existing_policy_list.keys():
                 is_policy_available = True
@@ -675,9 +647,8 @@ def create_protection_jobs():
     sql_parent_source = None
     existing_job_list = {}
     active_protection_jobs = []
-    job_prefix = configparser["import_cluster_config"]["job_prefix"]
-    job_suffix = configparser["import_cluster_config"]["job_suffix"]
-    jobs_to_import = resources_to_import.get("jobs", [])
+    job_prefix = configparser.get("import_cluster_config", "job_prefix")
+    job_suffix = configparser.get("import_cluster_config", "job_suffix")
     active_protection_jobs = cluster_dict.get("protection_jobs", [])
 
     # Fetch Sql parent source id.
@@ -690,7 +661,12 @@ def create_protection_jobs():
     for job in existing_jobs:
         existing_job_list[job.name] = job.id
 
+
     try:
+        selected_jobs = configparser.get(
+            "import_cluster_config", "selected_jobs")
+        jobs_to_import = [
+            job.strip() for job in selected_jobs.split(",") if selected_jobs]
         for protection_job in active_protection_jobs:
             source_list = []
             _parent_id = None
@@ -982,17 +958,10 @@ def create_remote_clusters():
     for cluster in existing_cluster_list:
         repl_list[cluster.name] = cluster.cluster_id
 
-    remote_clusters_to_import = resources_to_import.get("remote_clusters", [])
     # If the remote cluster exists then get the ID.
     for cluster in remote_cluster_list:
         # Check the remote cluster registered is not the current cluster.
         if cluster.remote_ips[0] == import_cluster_ip:
-            continue
-        if remote_clusters_to_import and cluster.remote_ips[0] not in \
-            remote_clusters_to_import:
-            # If cluster is not listed under required remote cluster list,
-            # cluster is not imported, if list is empty all the clusters are
-            # imported.
             continue
         is_remote_cluster_available = False
         if cluster.name in repl_list.keys():

--- a/samples/project-anfield/resources.json
+++ b/samples/project-anfield/resources.json
@@ -1,0 +1,9 @@
+{
+    "jobs": [],
+    "views": [],
+    "policies": [],
+    "sources": [],
+    "viewboxes": [],
+    "external_targets": [],
+    "remote_clusters": []
+}

--- a/samples/project-anfield/resources.json
+++ b/samples/project-anfield/resources.json
@@ -1,9 +1,0 @@
-{
-    "jobs": [],
-    "views": [],
-    "policies": [],
-    "sources": [],
-    "viewboxes": [],
-    "external_targets": [],
-    "remote_clusters": []
-}


### PR DESCRIPTION
1) Option to provide prefix and suffix for imported protection jobs.
2) List of resources to be imported can be provided as json.
   i) If list is empty all the sources are imported, orelse only
      provided resources are imported.
   ii) resources include sources, policies, jobs, views , storage
       domains, targets and remote clusters.