### PR TITLE
Initial commit for Pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+--- 
+repos: 
+-  repo: https://github.com/psf/black
+   # Limits line length to 88, replace single quotes by double quotes, wrap function arguments.
+   rev: master
+   hooks: 
+    - id: black
+      language_version: python
+      args: [ --config=./pyproject.toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 88

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.20.0
 jsonpickle==0.7.1
 cachecontrol==0.11.7
 python-dateutil==2.5.3
+pre-commit==2.9.3


### PR DESCRIPTION
After installing pre-commit for first time, run

pre-commit => install command to install all the git hooks.
pre-commit run --all-files => all the files are updated.

Black formatter:
1. Will replace single quotes with double quotes.
2. Max line length 88.