### PR TITLE
   Anfield: Option to Ignore paused, inactive deleted jobs.

### DIFF
--- a/samples/project-anfield/config.ini
+++ b/samples/project-anfield/config.ini
@@ -3,6 +3,8 @@ cluster_ip=<ip>
 username=<user>
 password=<password>
 domain=<domain>
+# skip_jobs parameter is to ignore exporting paused and failover ready jobs.
+skip_jobs=true
 
 [import_cluster_config]
 cluster_ip=<ip>
@@ -12,17 +14,17 @@ domain=<domain>
 # api_pause_time parameter is for the wait time between the api execution.
 api_pause_time=2
 # pause_jobs parameter is for jobs to be paused on the target cluster.
-pause_jobs=True
+pause_jobs=true
 # override parameter is for job/policies/views/storage domain/sources to be
 # updated/overwritten on the target cluster.
-override=True
+override=false
 # gflag parameter is for to decide whether to import gflags.
-gflag=False
+gflag=no
 # prefix and suffix added to Jobname. By default no prefix/suffix is added.
 imported_job_prefix=
 imported_job_suffix=
 # List of jobs to be imported. Accepts list of comma separated strings.
-selected_jobs=job1,job2,job3
+selected_jobs=
 
 [Remote Cluster Name] # Remote Cluster 1
 password=<password>
@@ -32,7 +34,6 @@ password=<password>
 
 [vcenter_name] # vcenter Source
 password=<password>
-
 
 [s3-external-target] # s3 external Target
 secret_access_key=<secret-key>

--- a/samples/project-anfield/export_cluster_config.py
+++ b/samples/project-anfield/export_cluster_config.py
@@ -70,13 +70,15 @@ logger.setLevel(logging.INFO)
 logger.info("Exporting resources from cluster '%s'" % (
     configparser.get('export_cluster_config', 'cluster_ip')))
 
+# Skip paused jobs and failover ready jobs by setting this flag to true in config file.
+skip_jobs = configparser.getboolean('export_cluster_config', 'skip_jobs')
 
 cluster_dict = {
     "cluster_config": library.get_cluster_config(cohesity_client),
     "views": library.get_views(cohesity_client),
     "storage_domains": library.get_storage_domains(cohesity_client),
     "policies": library.get_protection_policies(cohesity_client),
-    "protection_jobs": library.get_protection_jobs(cohesity_client),
+    "protection_jobs": library.get_protection_jobs(cohesity_client, skip_jobs),
     "protection_sources": library.get_protection_sources(cohesity_client),
     "external_targets": library.get_external_targets(cohesity_client),
     "sources": library.get_protection_sources(cohesity_client),

--- a/samples/project-anfield/library.py
+++ b/samples/project-anfield/library.py
@@ -61,11 +61,15 @@ def get_views(cohesity_client):
     return views_list
 
 
-def get_protection_jobs(cohesity_client):
+def get_protection_jobs(cohesity_client, skip_jobs=False):
     protection_job_list = cohesity_client.protection_jobs.get_protection_jobs()
     active_job_list = []
     for job in protection_job_list:
-        if job.is_deleted or job.is_active == False:
+        # Jobs which are deleted are ignored.
+        if job.is_deleted:
+            continue
+        # Skip jobs which are paused or in-active(failover ready).
+        if skip_jobs and (job.is_paused or job.is_active == False):
             continue
         active_job_list.append(job)
         exported_res_dict["Protection Jobs"].append(job.name)


### PR DESCRIPTION
    1) While exporting resources, set skip_jobs field to true. This will ignore
    paused, inactive(failover ready) jobs.
    2) While creating protection policy with replication cluster, update the
    policy with correct clusterid.