### PR TITLE
Support for Azure Hot Blob External Target Import/Export

### DIFF
--- a/samples/project-anfield/config.ini
+++ b/samples/project-anfield/config.ini
@@ -40,29 +40,32 @@ password=<password>
 [Remote Cluster 2 Name] # Remote Cluster 2
 password=<password>
 
-[vcenter_name] # vcenter Source
+[vcenter.domain.com] # vcenter Source
 password=<password>
 
 [s3-external-target] # s3 external Target
 secret_access_key=<secret-key>
 
-[Isilon Source] # Isilon Source
+[sv-isilon] # Isilon Source
 password=<password>
 
-[Cassandra Source] # Nosql Source-Cassandra
+[x.x.x.x] # Nosql Source-Cassandra
 username=<ssh_username>
 password=<ssh_password>
 db_username=<database_username>
 db_password=<database_password>
 
-[Active Directory Name]
+[xyz.domain.com] # Active Directory Name
 username=<ad_user>
 password=<ad_password>
 machine_account=<list of comma separated values> #Optional
 
-[Qstar External Target]
+[x.x.x.x] # Qstar External Target
 password=<password>
 
-[NAS SMB Source]
+[x.x.x.x] # Azure Hot Blob External Target
+storage_access_key=<access key>
+
+[xyz.domain.com] # NAS SMB Source
 domain=<domain of smb user>
 password=<password>

--- a/samples/project-anfield/import_cluster_config.py
+++ b/samples/project-anfield/import_cluster_config.py
@@ -297,7 +297,29 @@ def create_vaults():
                     "config.ini, err is %s" % (vault.name, err)
                 )
 
-        if vault.config.amazon:  # Amazon s3 targets
+        elif vault.config.azure:  # Azure Hot Blob target.
+            try:
+                body = Vault()
+                _construct_body(body, vault)
+                storage_access_key = configparser.get(
+                    vault.name, "storage_access_key")
+                body.config.azure.storage_access_key = storage_access_key
+                resp = cohesity_client.vaults.create_vault(body)
+                external_targets[vault.id] = resp.id
+                imported_res_dict["External Targets"].append(body.name)
+                time.sleep(sleep_time)
+            except (APIException, RequestErrorErrorException) as e:
+                ERROR_LIST.append(
+                    "Error Adding Azure hot blob Target: %s, Failed with "
+                    "error: %s" % (vault.name, e)
+                )
+            except Exception as err:
+                ERROR_LIST.append(
+                    "Please add correct config for %s in "
+                    "config.ini, err is %s" % (vault.name, err)
+                )
+
+        elif vault.config.amazon:  # Amazon s3 targets
             try:
                 body = Vault()
                 _construct_body(body, vault)
@@ -321,7 +343,7 @@ def create_vaults():
                 ERROR_LIST.append(
                     "Please add correct config for %s in " "config.ini" % vault.name
                 )
-        if vault.config.nas:  # Generic s3 targets
+        elif vault.config.nas:  # Generic s3 targets
             body = Vault()
             _construct_body(body, vault)
             try:

--- a/samples/project-anfield/library.py
+++ b/samples/project-anfield/library.py
@@ -190,6 +190,8 @@ def get_external_targets(cohesity_client):
         # config[target.name] = dict()
         if target.config.amazon:
             config_dict[target.name] = ["secret_access_key"]
+        elif target.config.azure:
+            config_dict[target.name] = ["storage_access_key"]
         else:
             config_dict[target.name] = None
         exported_res_dict["External Targets"].append(target.name)
@@ -353,6 +355,7 @@ def auto_populate_config():
     # Update import and export config details from existing config.ini file.
     config["export_cluster_config"] = config_parser["export_cluster_config"]
     config["import_cluster_config"] = config_parser["import_cluster_config"]
+
     for section, keys in config_dict.items():
         config[section] = dict()
         if not keys:


### PR DESCRIPTION
1) Added support to import and export hot blob sources as
external targets.
2) Hot blob storage access key is required, script fetches the
key from config.ini file.
3) While exporting resources with --auto-fill-config key,
target name and storage_access_key section is added to
config.ini file.