### PR TITLE
Add basic OTP support for AuthManager

### DIFF
--- a/cohesity_management_sdk/configuration.py
+++ b/cohesity_management_sdk/configuration.py
@@ -63,6 +63,10 @@ class Configuration(object):
     # API Key patch
     api_key = None
 
+    # Optional: OTP support
+    otp_type = None
+    otp_code = None
+
     # All the environments the SDK can run in
     environments = {
         Environment.PRODUCTION: {

--- a/cohesity_management_sdk/http/auth/auth_manager.py
+++ b/cohesity_management_sdk/http/auth/auth_manager.py
@@ -43,6 +43,10 @@ class AuthManager:
         if Configuration.domain is not None:
             body.domain = Configuration.domain
 
+        if Configuration.otp_type:
+            body.otp_type = Configuration.otp_type
+            body.otp_code = Configuration.otp_code
+
         auth_controller = AccessTokensController(Configuration)
         token = auth_controller.create_generate_access_token(body)
         Configuration.auth_token = token


### PR DESCRIPTION
This commit should allow other classes that this base configuration to authenticate with OTP. For now, OTP must be supplied outside the config, and needs to be refreshed constantly. In the future, otp_code should be a function that generates a new code when referenced. Consider pyotp for this.