### PR TITLE
 Updated SDK dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/cohesity/management-sdk-python',
     packages=find_packages(),
     install_requires=[
-        'requests>=2.31.0, <3.0',
+        'requests>=2.25.1, <3.0',
         'cachecontrol>=0.11.7, <1.0',
         'python-dateutil>=2.5.3, <3.0'
     ]


### PR DESCRIPTION
    1) Python 3.6 supports requests <= 2.27.1 version and python 3.5
       supports requests <= 2.25.1
    2) Updated the minimum version for requests package in the setup
       file.
    3) With this change SDK will support 3.5+ python versions.